### PR TITLE
Target hardware address switched to reference correct MAC

### DIFF
--- a/index.js
+++ b/index.js
@@ -162,7 +162,8 @@ function try_ping(ip_address, packet, options, next) {
 
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
-			tha     : packet.payload.payload.sender_ha.toString()
+			tha     : packet.payload.payload.target_ha.toString(),
+			sha     : packet.payload.payload.sender_ha.toString(),
 		});
 	});
 

--- a/index.js
+++ b/index.js
@@ -162,7 +162,7 @@ function try_ping(ip_address, packet, options, next) {
 
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
-			tha     : packet.payload.payload.target_ha.toString()
+			tha     : packet.payload.payload.sender_ha.toString()
 		});
 	});
 


### PR DESCRIPTION
This addresses Issue #1 

`target` and `sender` are from the prospective of the sending system. When a system ("target") is responding to our ARP ping, it's actually called the `sender` not that `target`.  This commit fixes an issue where our own MAC was returned instead of the system we're scanning.