### PR TITLE
Correctly handle session close

### DIFF
--- a/index.js
+++ b/index.js
@@ -164,8 +164,8 @@ function try_ping(ip_address, packet, options, next) {
 	});
 
 	session.on("end", function(session) {
-    session.close();
-    session = null;
+		session.close();
+		session = null;
 	});
 
 	session.inject(packet);

--- a/index.js
+++ b/index.js
@@ -157,13 +157,15 @@ function try_ping(ip_address, packet, options, next) {
 
 		time = process.hrtime(time);
 
-		session.close();
-		session = null;
-
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
 			tha     : packet.payload.payload.target_ha.toString()
 		});
+	});
+
+	session.on("end", function(session) {
+    session.close();
+    session = null;
 	});
 
 	session.inject(packet);


### PR DESCRIPTION
This addresses Issue #2 

This commit corrects an issue where closing the session and setting it to `NULL` before the "end" session event fired caused the native `pcap2` module to segfault by referencing a NULL pointer (the session).

This is resolved by placing the session closing on the session end event emitter handler.  This way the session will only be cleaned up when it's done and we avoid the race condition.