### PR TITLE
Added IP address of the responding host to the Ping result

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ const arp = require("arping");
 
 arp.ping("192.168.0.1", (err, info) => {
 	if (err) throw err; // Timeout, ...
-
-	console.log("%s responded in %s secs", info.tha, info.elapsed); // THA = target hardware address
+	// THA = target hardware address
+	// TIP = target IP address
+	console.log("%s (%s) responded in %s secs", info.tha, info.tip, info.elapsed);
 });
 ```

--- a/index.js
+++ b/index.js
@@ -162,7 +162,8 @@ function try_ping(ip_address, packet, options, next) {
 
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
-			tha     : packet.payload.payload.target_ha.toString()
+			tha     : packet.payload.payload.target_ha.toString(),
+			tip     : packet.payload.payload.sender_pa.toString()
 		});
 	});
 

--- a/index.js
+++ b/index.js
@@ -163,7 +163,9 @@ function try_ping(ip_address, packet, options, next) {
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
 			tha     : packet.payload.payload.target_ha.toString(),
-			tip     : packet.payload.payload.sender_pa.toString()
+			sha     : packet.payload.payload.send_ha.toString(),
+			tip     : packet.payload.payload.target_pa.toString(),
+			sip     : packet.payload.payload.sender_pa.toString(),
 		});
 	});
 

--- a/index.js
+++ b/index.js
@@ -163,7 +163,7 @@ function try_ping(ip_address, packet, options, next) {
 		return done(null, {
 			elapsed : time[0] + time[1] / NS_PER_SEC,
 			tha     : packet.payload.payload.target_ha.toString(),
-			sha     : packet.payload.payload.send_ha.toString(),
+			sha     : packet.payload.payload.sender_ha.toString(),
 			tip     : packet.payload.payload.target_pa.toString(),
 			sip     : packet.payload.payload.sender_pa.toString(),
 		});


### PR DESCRIPTION
Although we should know what IP address responds to us, there's little reason to leave this data out.  In this commit we add the IP address to the Ping response so we can always know what IP address is correlated with a resulting MAC address.  This could be helpful when scanning many IP addresses.