### PR TITLE
added support for nodejs 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const NS_PER_SEC = Math.pow(10, 9);
 
 const os         = require("os");
 const raw        = require("raw-socket");
-const pcap       = require("pcap2");
+const pcap       = require("pcap");
 const types      = require("./types");
 
 exports.ping = (...args) => {
@@ -147,7 +147,7 @@ function try_ping(ip_address, packet, options, next) {
 		return next(null, info);
 	};
 
-	let session = new pcap.Session("", { filter : "arp" });
+	let session = pcap.createSession("", "arp");
 	let time    = process.hrtime();
 
 	session.on("packet", (raw) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,37 @@
+{
+	"name": "arping",
+	"version": "0.1.1",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"nan": {
+			"version": "2.14.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+			"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg=="
+		},
+		"pcap": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/pcap/-/pcap-2.1.0.tgz",
+			"integrity": "sha512-immYRefC8nWvfH0HbmB/O+8xcd5TsN+VzOusFY0BNpQtZXlKwZo/2AiZHAukcC41vcgVI7dUrBxQCsQc71NaOw==",
+			"requires": {
+				"nan": "^2.0.9",
+				"socketwatcher": "git+https://github.com/bytzdev/node-socketwatcher.git"
+			}
+		},
+		"raw-socket": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/raw-socket/-/raw-socket-1.7.0.tgz",
+			"integrity": "sha512-mXqWihgwaFNmV5le0dWk5o+03M3A2zBIkC9BNaE6R0CJN9eYot++j2FIqgNSDq6/Vmu32PPI155SiiWNV2yyFQ==",
+			"requires": {
+				"nan": "2.14.*"
+			}
+		},
+		"socketwatcher": {
+			"version": "git+https://github.com/bytzdev/node-socketwatcher.git#d252d3f8c45f565a0a48ebd155d4f9e4666798d9",
+			"from": "git+https://github.com/bytzdev/node-socketwatcher.git",
+			"requires": {
+				"nan": "^2.0.9"
+			}
+		}
+	}
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name"         : "arping",
-	"version"      : "0.1.0",
+	"version"      : "0.1.1",
 	"description"  : "ARP ping using raw sockets",
 	"main"         : "index.js",
 	"keywords"     : [ "arp", "ping" ],
@@ -8,6 +8,7 @@
 	"repository"   : "git@github.com:dresende/node-arping.git",
 	"license"      : "MIT",
 	"dependencies" : {
-		"pcap2" : "^3.0.4"
+			"pcap" : "^2.1.0",
+			"raw-socket": "^1.7.0"
 	}
 }


### PR DESCRIPTION
The module pcap2 uses a version of socketwatcher that cannot be compiled with Node.js v10.x. The pcap module uses a fork from socketwatcher that is compatible with Node.js 10.

I changed the dependency and the code accordingly. Tested with Node.js v10.16.2